### PR TITLE
Update to version 2.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ default is MD5, but a stronger/longer checksum is preferred. PowerShell defaults
 to SHA256, which is fine.
 
 ```
-PS> Get-FileHash '.\ScreenToGif x.y.z.zip'
+PS> Get-FileHash '.\ScreenToGif.x.y.z.Portable.zip'
 
 Algorithm   Hash                                                               Path
 ---------   ----                                                               ----

--- a/screentogif/screentogif.nuspec
+++ b/screentogif/screentogif.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>screentogif</id>
     <title>Screen To Gif</title>
-    <version>2.33.1</version>
+    <version>2.34.0</version>
     <authors>ScreenToGif</authors>
     <owners>Nicke Manarin</owners>
     <summary>This tool allows you to record a selected area of your screen and save it as a gif or video.</summary>
@@ -25,7 +25,7 @@
     <projectSourceUrl>https://github.com/NickeManarin/ScreenToGif/tree/master</projectSourceUrl>
     <packageSourceUrl>https://github.com/NickeManarin/ScreenToGif-Chocolatey</packageSourceUrl>
     <docsUrl>https://github.com/NickeManarin/ScreenToGif/wiki</docsUrl>
-    <releaseNotes>https://github.com/NickeManarin/ScreenToGif/releases/tag/2.33.1</releaseNotes>
+    <releaseNotes>https://github.com/NickeManarin/ScreenToGif/releases/tag/2.34</releaseNotes>
     <bugTrackerUrl>https://github.com/NickeManarin/ScreenToGif/issues</bugTrackerUrl>
     <mailingListUrl>https://github.com/NickeManarin/ScreenToGif/issues</mailingListUrl>
     <tags>screen recording recorder gif editor foss media </tags>

--- a/screentogif/tools/chocolateyInstall.ps1
+++ b/screentogif/tools/chocolateyInstall.ps1
@@ -5,8 +5,8 @@ $exe = Join-Path $content 'ScreenToGif.exe'
 
 Install-ChocolateyZipPackage `
     -PackageName 'screentogif' `
-    -Url 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.33.1/ScreenToGif.2.33.1.Portable.zip' `
-    -Checksum 'D38A9EFFE0574AAAC614449DE96045C270786E03BDFD389FB6B2BF607A5FE525' `
+    -Url 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.34/ScreenToGif.2.34.Portable.zip' `
+    -Checksum '3BCAE4ACFE7B8670FD818B986E3106ECFA45C0FF8F2DEC67EAA8C4E80CF6BAE2' `
     -ChecksumType 'SHA256' `
     -UnzipLocation $content
 


### PR DESCRIPTION
Closes #13 .

I also included a minor readme update to match the file naming convention of the portable zips.