### PR TITLE
Changed deps from 4.4.1<=ffmpeg to  4.4.1<=ffmpeg<6

### DIFF
--- a/screentogif.install/screentogif.install.nuspec
+++ b/screentogif.install/screentogif.install.nuspec
@@ -37,7 +37,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
     <iconUrl>https://cdn.jsdelivr.net/gh/NickeManarin/ScreenToGif-Chocolatey@master/screentogif.png</iconUrl>
 
     <dependencies>
-      <dependency id="ffmpeg" version="4.4.1"/>
+      <dependency id="ffmpeg" version="[4.4.1,6)"/>
     </dependencies>
   </metadata>
 </package>

--- a/screentogif.install/screentogif.install.nuspec
+++ b/screentogif.install/screentogif.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>screentogif.install</id>
     <title>Screen To Gif (Install)</title>
-    <version>2.37.0</version>
+    <version>2.38.1</version>
     <authors>ScreenToGif</authors>
     <owners>Nicke Manarin</owners>
     <summary>This tool allows you to record a selected area of your screen and save it as a gif or video.</summary>
@@ -28,7 +28,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
     <projectSourceUrl>https://github.com/NickeManarin/ScreenToGif/tree/master</projectSourceUrl>
     <packageSourceUrl>https://github.com/NickeManarin/ScreenToGif-Chocolatey</packageSourceUrl>
     <docsUrl>https://github.com/NickeManarin/ScreenToGif/wiki</docsUrl>
-    <releaseNotes>https://github.com/NickeManarin/ScreenToGif/releases/tag/2.37.0</releaseNotes>
+    <releaseNotes>https://github.com/NickeManarin/ScreenToGif/releases/tag/2.38.1</releaseNotes>
     <bugTrackerUrl>https://github.com/NickeManarin/ScreenToGif/issues</bugTrackerUrl>
     <mailingListUrl>https://github.com/NickeManarin/ScreenToGif/issues</mailingListUrl>
     <tags>screen recording recorder gif editor foss media</tags>

--- a/screentogif.install/tools/chocolateyInstall.ps1
+++ b/screentogif.install/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
 $softwareName = 'ScreenToGif'
-$version = '2.37'
+$version = '2.38.1'
 if ($version -eq (Get-UninstallRegistryKey "$softwareName").DisplayVersion) {
   Write-Host "ScreenToGif $version is already installed."
   return
@@ -16,14 +16,14 @@ if ($version -eq (Get-UninstallRegistryKey "$softwareName").DisplayVersion) {
 $packageArgs = @{
   packageName    = 'screentogif.install'
   fileType       = 'msi'
-  url            = 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.37/ScreenToGif.2.37.Setup.x86.msi'
-  url64bit       = 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.37/ScreenToGif.2.37.Setup.x64.msi'
+  url            = 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.38.1/ScreenToGif.2.38.1.Setup.x86.msi'
+  url64bit       = 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.38.1/ScreenToGif.2.38.1.Setup.x64.msi'
 
   softwareName   = "$softwareName"
 
-  checksum       = '8A144639D3F13E14BBB25FC1F9CEFE8AC03C48284AFFE6BCC409837B72C4F0C1'
+  checksum       = 'C34F34CCEB74E970FD4477E888AAB6DB7A92CA9B0C1EE99B278071D8576E36F6'
   checksumType   = 'sha256'
-  checksum64     = 'C76E12EF9052CA8A163DA6385D75914E64203419ABF56AE3A417670EEDFAB868'
+  checksum64     = '969897125DA184EA7073AB6C50309EBADEEB93784B4EEB331AE575997CAD64DD'
   checksumType64 = 'sha256'
 
   silentArgs     = '/qn'

--- a/screentogif.portable/screentogif.portable.nuspec
+++ b/screentogif.portable/screentogif.portable.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>screentogif.portable</id>
     <title>Screen To Gif (Portable)</title>
-    <version>2.37.0</version>
+    <version>2.38.1</version>
     <authors>ScreenToGif</authors>
     <owners>Nicke Manarin</owners>
     <summary>This tool allows you to record a selected area of your screen and save it as a gif or video.</summary>
@@ -28,7 +28,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
     <projectSourceUrl>https://github.com/NickeManarin/ScreenToGif/tree/master</projectSourceUrl>
     <packageSourceUrl>https://github.com/NickeManarin/ScreenToGif-Chocolatey</packageSourceUrl>
     <docsUrl>https://github.com/NickeManarin/ScreenToGif/wiki</docsUrl>
-    <releaseNotes>https://github.com/NickeManarin/ScreenToGif/releases/tag/2.37.0</releaseNotes>
+    <releaseNotes>https://github.com/NickeManarin/ScreenToGif/releases/tag/2.38.1</releaseNotes>
     <bugTrackerUrl>https://github.com/NickeManarin/ScreenToGif/issues</bugTrackerUrl>
     <mailingListUrl>https://github.com/NickeManarin/ScreenToGif/issues</mailingListUrl>
     <tags>screen recording recorder gif editor foss media</tags>

--- a/screentogif.portable/screentogif.portable.nuspec
+++ b/screentogif.portable/screentogif.portable.nuspec
@@ -37,7 +37,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
     <iconUrl>https://cdn.jsdelivr.net/gh/NickeManarin/ScreenToGif-Chocolatey@master/screentogif.png</iconUrl>
 
     <dependencies>
-      <dependency id="ffmpeg" version="4.4.1"/>
+      <dependency id="ffmpeg" version="[4.4.1,6)"/>
     </dependencies>
   </metadata>
 </package>

--- a/screentogif.portable/tools/chocolateyInstall.ps1
+++ b/screentogif.portable/tools/chocolateyInstall.ps1
@@ -5,10 +5,10 @@ $exe = Join-Path $content 'ScreenToGif.exe'
 
 Install-ChocolateyZipPackage `
     -PackageName 'screentogif' `
-    -Url 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.37/ScreenToGif.2.37.Portable.x86.zip' `
-    -Url64bit  'https://github.com/NickeManarin/ScreenToGif/releases/download/2.37/ScreenToGif.2.37.Portable.x64.zip' `
-    -Checksum '04158A428FD366FE7D0B6B4C26542C85E5F9FD9F2C08B43E23E14776F3EEAB3F' `
-    -Checksum64 '7319888631F5B747EDB90A44B83DC594C2A6D14FF3DB5D32830F9DD7ECDD0ABA' `
+    -Url 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.38.1/ScreenToGif.2.38.1.Portable.x86.zip' `
+    -Url64bit  'https://github.com/NickeManarin/ScreenToGif/releases/download/2.38.1/ScreenToGif.2.38.1.Portable.x64.zip' `
+    -Checksum '855032B53AE6BEAFBD63DDFEB47C53634062E7E31A97FA9041B24E368318D6A7' `
+    -Checksum64 '400FAB6E5709250AF464AE8B8D0696EB4B60A8D22F7B9454496E0FD263ED144F' `
     -ChecksumType 'SHA256' `
     -ChecksumType64 'SHA256' `
     -UnzipLocation $content

--- a/screentogif/screentogif.nuspec
+++ b/screentogif/screentogif.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>screentogif</id>
     <title>Screen To Gif (Portable)</title>
-    <version>2.37.0</version>
+    <version>2.38.1</version>
     <authors>ScreenToGif</authors>
     <owners>Nicke Manarin</owners>
     <summary>This tool allows you to record a selected area of your screen and save it as a gif or video.</summary>
@@ -28,7 +28,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
     <projectSourceUrl>https://github.com/NickeManarin/ScreenToGif/tree/master</projectSourceUrl>
     <packageSourceUrl>https://github.com/NickeManarin/ScreenToGif-Chocolatey</packageSourceUrl>
     <docsUrl>https://github.com/NickeManarin/ScreenToGif/wiki</docsUrl>
-    <releaseNotes>https://github.com/NickeManarin/ScreenToGif/releases/tag/2.37.0</releaseNotes>
+    <releaseNotes>https://github.com/NickeManarin/ScreenToGif/releases/tag/2.38.1</releaseNotes>
     <bugTrackerUrl>https://github.com/NickeManarin/ScreenToGif/issues</bugTrackerUrl>
     <mailingListUrl>https://github.com/NickeManarin/ScreenToGif/issues</mailingListUrl>
     <tags>screen recording recorder gif editor foss media</tags>
@@ -38,7 +38,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
 
     <dependencies>
       <dependency id="ffmpeg" version="[4.4.1,6)"/>
-      <dependency id="screentogif.portable" version="2.37.0"/>
+      <dependency id="screentogif.portable" version="2.38.1"/>
     </dependencies>
   </metadata>
 </package>

--- a/screentogif/screentogif.nuspec
+++ b/screentogif/screentogif.nuspec
@@ -37,7 +37,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
     <iconUrl>https://cdn.jsdelivr.net/gh/NickeManarin/ScreenToGif-Chocolatey@master/screentogif.png</iconUrl>
 
     <dependencies>
-      <dependency id="ffmpeg" version="4.2.2"/>
+      <dependency id="ffmpeg" version="[4.4.1,6)"/>
       <dependency id="screentogif.portable" version="2.37.0"/>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Until ffmpeg 6 support in screentogif change dependency from 4.4.1<=ffmpeg to  4.4.1<=ffmpeg<6

Thank you so much for this project and maintaining it, it is so powerful as a teaching aid.