### PR TITLE
Fix .ps1 to fetch 2.39

### DIFF
--- a/screentogif.install/screentogif.install.nuspec
+++ b/screentogif.install/screentogif.install.nuspec
@@ -37,7 +37,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
     <iconUrl>https://cdn.jsdelivr.net/gh/NickeManarin/ScreenToGif-Chocolatey@master/screentogif.png</iconUrl>
 
     <dependencies>
-      <dependency id="ffmpeg" version="4.4.1"/>
+      <dependency id="ffmpeg" version="6.0"/>
     </dependencies>
   </metadata>
 </package>

--- a/screentogif.install/tools/chocolateyInstall.ps1
+++ b/screentogif.install/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
 $softwareName = 'ScreenToGif'
-$version = '2.38.1'
+$version = '2.39'
 if ($version -eq (Get-UninstallRegistryKey "$softwareName").DisplayVersion) {
   Write-Host "ScreenToGif $version is already installed."
   return
@@ -16,14 +16,14 @@ if ($version -eq (Get-UninstallRegistryKey "$softwareName").DisplayVersion) {
 $packageArgs = @{
   packageName    = 'screentogif.install'
   fileType       = 'msi'
-  url            = 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.38.1/ScreenToGif.2.38.1.Setup.x86.msi'
-  url64bit       = 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.38.1/ScreenToGif.2.38.1.Setup.x64.msi'
+  url            = "https://github.com/NickeManarin/ScreenToGif/releases/download/${version}/ScreenToGif.${version}.Setup.x86.msi"
+  url64bit       = "https://github.com/NickeManarin/ScreenToGif/releases/download/${version}/ScreenToGif.${version}.Setup.x64.msi"
 
   softwareName   = "$softwareName"
 
-  checksum       = 'C34F34CCEB74E970FD4477E888AAB6DB7A92CA9B0C1EE99B278071D8576E36F6'
+  checksum       = '36427753B5EA4D853689565218CB5D1DCE6BA99EA75AEF584946C1EFF25E6F97'
   checksumType   = 'sha256'
-  checksum64     = '969897125DA184EA7073AB6C50309EBADEEB93784B4EEB331AE575997CAD64DD'
+  checksum64     = 'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855'
   checksumType64 = 'sha256'
 
   silentArgs     = '/qn'

--- a/screentogif.portable/screentogif.portable.nuspec
+++ b/screentogif.portable/screentogif.portable.nuspec
@@ -37,7 +37,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
     <iconUrl>https://cdn.jsdelivr.net/gh/NickeManarin/ScreenToGif-Chocolatey@master/screentogif.png</iconUrl>
 
     <dependencies>
-      <dependency id="ffmpeg" version="4.4.1"/>
+      <dependency id="ffmpeg" version="6.0"/>
     </dependencies>
   </metadata>
 </package>

--- a/screentogif.portable/tools/chocolateyInstall.ps1
+++ b/screentogif.portable/tools/chocolateyInstall.ps1
@@ -5,10 +5,10 @@ $exe = Join-Path $content 'ScreenToGif.exe'
 
 Install-ChocolateyZipPackage `
     -PackageName 'screentogif' `
-    -Url 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.38.1/ScreenToGif.2.38.1.Portable.x86.zip' `
-    -Url64bit  'https://github.com/NickeManarin/ScreenToGif/releases/download/2.38.1/ScreenToGif.2.38.1.Portable.x64.zip' `
-    -Checksum '855032B53AE6BEAFBD63DDFEB47C53634062E7E31A97FA9041B24E368318D6A7' `
-    -Checksum64 '400FAB6E5709250AF464AE8B8D0696EB4B60A8D22F7B9454496E0FD263ED144F' `
+    -Url 'https://github.com/NickeManarin/ScreenToGif/releases/download/2.39/ScreenToGif.2.39.Portable.x86.zip' `
+    -Url64bit  'https://github.com/NickeManarin/ScreenToGif/releases/download/2.39/ScreenToGif.2.39.Portable.x64.zip' `
+    -Checksum 'B4B8467A7A708D6C7DE58DE641D3695E5BD63B2918AA9220BED6A20A34F069DE' `
+    -Checksum64 '53CFDFF0D43B10FE2E36090DDBFCB621D117FEA3DD926931DEDBF221A3159ED1' `
     -ChecksumType 'SHA256' `
     -ChecksumType64 'SHA256' `
     -UnzipLocation $content

--- a/screentogif/screentogif.nuspec
+++ b/screentogif/screentogif.nuspec
@@ -37,7 +37,7 @@ Screen, webcam and sketchboard recorder with an integrated editor.
     <iconUrl>https://cdn.jsdelivr.net/gh/NickeManarin/ScreenToGif-Chocolatey@master/screentogif.png</iconUrl>
 
     <dependencies>
-      <dependency id="ffmpeg" version="4.4.1"/>
+      <dependency id="ffmpeg" version="6.0"/>
       <dependency id="screentogif.portable" version="2.39.0"/>
     </dependencies>
   </metadata>


### PR DESCRIPTION
The .ps1 scripts were still pulling 2.38.1. I have updated them to pull 2.39 and ffmpeg 6.0 if it is available. 

I have tweaked one of the scripts to use the $version variable you created in the URLs. I held off rewriting the other one to include a version number as I am not the most confident powershell user.

Also, I hope the ffmpeg v6 change is not a problem!

Thanks for all your hard work.